### PR TITLE
Add JetBrains config file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 data_*/
 mono_crash.*.json
 .DS_Store
+
+# Jetbrains IDE config
+.idea


### PR DESCRIPTION
Just adds `.idea` to the `.gitignore` file so we don't clobber one another's Rider config.